### PR TITLE
record the time jobs spent in queue waiting to be picked up

### DIFF
--- a/lib/ResqueStatsD.php
+++ b/lib/ResqueStatsD.php
@@ -11,17 +11,17 @@ class ResqueStatsd
 {
     const STATSD_TIMER   = 'ms';
     const STATSD_COUNTER = 'c';
-    
+
     /**
      * @var string Prefix to add to metrics submitted to StatsD.
      */
     private static $prefix = 'resque';
-    
+
     /**
      * @var string Hostname when connecting to StatsD.
      */
     private static $host   = 'localhost';
-    
+
     /**
      * @var int Port StatsD is running on.
      */
@@ -41,11 +41,11 @@ class ResqueStatsd
         Resque_Event::listen('beforeFork', 'ResqueStatsd::beforeFork');
         Resque_Event::listen('afterPerform', 'ResqueStatsd::afterPerform');
         Resque_Event::listen('onFailure', 'ResqueStatsd::onFailure');
-        
+
         // Add support for php-resque-scheduler
         Resque_Event::listen('afterSchedule', 'ResqueStatsd::afterSchedule');
     }
-    
+
     /**
      * Set the host/port combination of StatsD.
      *
@@ -57,7 +57,7 @@ class ResqueStatsd
         self::$host = $host;
         self::$port = $port;
     }
-    
+
     /**
      * Override the prefix for metrics that are submitted to StatsD.
      *
@@ -67,7 +67,7 @@ class ResqueStatsd
     {
         self::$prefix = $prefix;
     }
-    
+
     /**
      * Submit metrics for a queue and job whenever a job is pushed to a queue.
      *
@@ -80,7 +80,7 @@ class ResqueStatsd
         self::sendMetric(self::STATSD_COUNTER, 'queue.' . $queue . '.enqueued', 1);
         self::sendMetric(self::STATSD_COUNTER, 'job.' . $class . '.enqueued', 1);
     }
-    
+
     /**
      * Submit metrics for a queue and job whenever a job is scheduled in php-resque-scheduler.
      *
@@ -94,9 +94,10 @@ class ResqueStatsd
         self::sendMetric(self::STATSD_COUNTER, 'queue.' . $queue . '.scheduled', 1);
         self::sendMetric(self::STATSD_COUNTER, 'job.' . $class . '.scheduled', 1);
     }
-    
+
     /**
-     * Begin tracking execution time before forking out to run a job in a php-resque worker.
+     * Begin tracking execution time before forking out to run a job in a php-resque worker
+     * and submits the metrics for the duration of a job spend waiting in the queue.
      *
      * Time tracking begins in `beforeFork` to ensure that the time spent for forking
      * and any hooks registered for `beforePerform` is also tracked.
@@ -106,8 +107,12 @@ class ResqueStatsd
     public static function beforeFork(Resque_Job $job)
     {
         $job->statsDStartTime = microtime(true);
+
+        $queuedTime = round(microtime(true) - $job->payload['queue_time']) * 1000;
+        self::sendMetric(self::STATSD_TIMER, 'queue.' . $job->queue . '.queued', $queuedTime);
+        self::sendMetric(self::STATSD_TIMER, 'job.' . $job->payload['class'] . '.queued', $queuedTime);
     }
-    
+
     /**
      * Submit metrics for a queue and job as soon as job has finished executing successfully.
      *
@@ -117,7 +122,7 @@ class ResqueStatsd
     {
         self::sendMetric(self::STATSD_COUNTER, 'queue.' . $job->queue . '.finished', 1);
         self::sendMetric(self::STATSD_COUNTER, 'job.' . $job->payload['class'] . '.finished', 1);
-        
+
         $executionTime = round(microtime(true) - $job->statsDStartTime) * 1000;
         self::sendMetric(self::STATSD_TIMER, 'queue.' . $job->queue . '.processed', $executionTime);
         self::sendMetric(self::STATSD_TIMER, 'job.' . $job->payload['class'] . '.processed', $executionTime);
@@ -134,7 +139,7 @@ class ResqueStatsd
         self::sendMetric(self::STATSD_COUNTER, 'queue.' . $job->queue . '.failed', 1);
         self::sendMetric(self::STATSD_COUNTER, 'job.' . $job->payload['class'] . '.failed', 1);
     }
-    
+
     /**
      * Return a tuple containing the StatsD host and port to submit metrics to.
      *
@@ -159,7 +164,7 @@ class ResqueStatsd
         else if(!empty($_ENV['GRAPHITE_HOST'])) {
             $host = $_ENV['GRAPHITE_HOST'];
         }
-        
+
         if (!empty($_ENV['STATSD_PORT'])) {
             $port = $_ENV['STATSD_PORT'];
         }
@@ -167,10 +172,10 @@ class ResqueStatsd
         if (substr_count($host, ':') == 1) {
             list($host, $port) = explode(':', $host);
         }
-    
+
         return array($host, $port);
     }
-    
+
     /**
      * Submit a metric of the given type, name and value to StatsD.
      *
@@ -183,7 +188,7 @@ class ResqueStatsd
     private static function sendMetric($type, $name, $value)
     {
         list($host, $port) = self::getStatsDHost();
-        
+
         if (empty($host) || empty($port)) {
             return false;
         }
@@ -192,7 +197,7 @@ class ResqueStatsd
         if (!$fp || $errno > 0) {
             return false;
         }
-        
+
         $metric = self::$prefix . '.' . $name . ':' . $value . '|' . $type;
         if (!fwrite($fp, $metric)) {
             return false;


### PR DESCRIPTION
Track the time jobs spent in the queue waiting to be pickup.

This can be useful to tell if we are adding jobs at a rate that is greater than workers can handle them, which is a good indicator that we should add more workers or try to decrease the number of jobs.

Depends on https://github.com/chrisboulton/php-resque/pull/206
